### PR TITLE
feat: configure Clerk middleware sign-in URL

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,11 +2,14 @@ import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server"
 
 const isProtectedRoute = createRouteMatcher(["/dashboard(.*)", "/admin(.*)"])
 
-export default clerkMiddleware(async (auth, req) => {
-  if (isProtectedRoute(req)) {
-    await auth.protect({ unauthenticatedUrl: "/auth/sign-in" })
-  }
-})
+export default clerkMiddleware(
+  async (auth, req) => {
+    if (isProtectedRoute(req)) {
+      await auth.protect()
+    }
+  },
+  { signInUrl: "/auth/sign-in" }
+)
 
 export const config = {
   matcher: [


### PR DESCRIPTION
## Summary
- direct unauthenticated users to `/auth/sign-in` via Clerk middleware config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Cannot find module '@radix-ui/react-label')*
- `curl -I http://localhost:3000/dashboard` *(fails: Cannot find module '@tailwindcss/postcss')*

------
https://chatgpt.com/codex/tasks/task_e_68c56dc702608322accb37d72b22dd64