### PR TITLE
feat: redirect users to dashboard after sign-in

### DIFF
--- a/app/auth/sign-in/[[...sign-in]]/page.tsx
+++ b/app/auth/sign-in/[[...sign-in]]/page.tsx
@@ -9,6 +9,8 @@ export default function SignInPage() {
           <p className="text-gray-600">Entre na sua conta</p>
         </div>
         <SignIn
+          afterSignInUrl="/dashboard"
+          afterSignUpUrl="/pending"
           appearance={{
             elements: {
               rootBox: "mx-auto",


### PR DESCRIPTION
## Summary
- redirect to /dashboard after sign in and to /pending after sign up

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c576e68280832290344c4f606f28af