### PR TITLE
Configure Clerk middleware to use custom auth paths

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -8,7 +8,10 @@ export default clerkMiddleware(
       await auth.protect()
     }
   },
-  { signInUrl: "/auth/sign-in" }
+  {
+    signInUrl: "/auth/sign-in",
+    signUpUrl: "/auth/sign-up",
+  }
 )
 
 export const config = {


### PR DESCRIPTION
## Summary
- configure Clerk middleware to route unauthenticated users to `/auth/sign-in` and sign-ups to `/auth/sign-up`

## Testing
- `npm run lint`
- `curl -I http://localhost:3000/dashboard` *(failed: Clerk publishable key invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68c579219b1c8322be5cc7142fd2fb77