### PR TITLE
fix: return auth protect in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -3,9 +3,12 @@ import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server"
 const isProtectedRoute = createRouteMatcher(["/dashboard(.*)", "/admin(.*)"])
 
 export default clerkMiddleware(
-  async (auth, req) => {
+  (auth, req) => {
     if (isProtectedRoute(req)) {
-      await auth.protect()
+      // Return the auth.protect() call so unauthenticated requests are
+      // properly redirected by Clerk instead of falling through and
+      // triggering a client-side redirect loop.
+      return auth.protect()
     }
   },
   {


### PR DESCRIPTION
## Summary
- ensure middleware returns auth.protect so unauthenticated requests are redirected by Clerk

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5e0bda7f08322be11c833318f3977