### PR TITLE
fix: ensure dynamic rendering for auth pages

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -8,6 +8,8 @@ import { UserButton } from "@clerk/nextjs"
 import { Clock, CheckCircle, XCircle, ExternalLink, Settings } from "lucide-react"
 import Link from "next/link"
 
+export const dynamic = "force-dynamic"
+
 interface UserApp {
   id: string
   app: {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,8 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import Link from "next/link"
 
+export const dynamic = "force-dynamic"
+
 export default async function HomePage() {
   const { userId } = await safeAuth()
 

--- a/app/pending/page.tsx
+++ b/app/pending/page.tsx
@@ -5,6 +5,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Clock } from "lucide-react"
 import { UserButton } from "@clerk/nextjs"
 
+export const dynamic = "force-dynamic"
+
 export default async function PendingPage() {
   const { userId } = await safeAuth()
 


### PR DESCRIPTION
## Summary
- prevent static rendering of auth-dependent pages by forcing dynamic evaluation

## Testing
- `pnpm lint`
- `pnpm run test` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_68c5e0bda7f08322be11c833318f3977